### PR TITLE
Fixed indexEntry parsing bug 

### DIFF
--- a/src/main/java/tv/amwa/maj/io/mxf/MXFBuilder.java
+++ b/src/main/java/tv/amwa/maj/io/mxf/MXFBuilder.java
@@ -746,7 +746,7 @@ public class MXFBuilder {
 		throws NullPointerException {
 
 		if (toWrite == null)
-			throw new NullPointerException("Cannot calculat the length as a local set value for a null metadata object.");
+			throw new NullPointerException("Cannot calculate the length as a local set value for a null metadata object.");
 
 		ClassDefinition classOfMetadata = MediaEngine.getClassDefinition(toWrite);
 		SortedMap<? extends PropertyDefinition,? extends PropertyValue> properties = classOfMetadata.getProperties(toWrite);

--- a/src/main/java/tv/amwa/maj/io/mxf/MXFBuilder.java
+++ b/src/main/java/tv/amwa/maj/io/mxf/MXFBuilder.java
@@ -107,10 +107,11 @@ public class MXFBuilder {
 		Warehouse.lookForClass(PrimerPackImpl.class);
 		Warehouse.lookForClass(RandomIndexPackImpl.class);
 		Warehouse.lookForClass(IndexTableSegmentImpl.class);
-		Warehouse.registerTypes(TypeDefinitions.class, MXFConstants.RP210_NAMESPACE, MXFConstants.RP210_PREFIX);
-
+		
 		TypeDefinitionRecordImpl.registerInterfaceMapping(DeltaEntry.class, DeltaEntryImpl.class);
 		TypeDefinitionRecordImpl.registerInterfaceMapping(IndexEntry.class, IndexEntryImpl.class);
+		
+		Warehouse.registerTypes(TypeDefinitions.class, MXFConstants.RP210_NAMESPACE, MXFConstants.RP210_PREFIX);
 
 		mxfRegistration = true;
 	}

--- a/src/main/java/tv/amwa/maj/io/mxf/impl/IndexTableSegmentImpl.java
+++ b/src/main/java/tv/amwa/maj/io/mxf/impl/IndexTableSegmentImpl.java
@@ -389,7 +389,11 @@ public class IndexTableSegmentImpl
 			optional = true,
 			uniqueIdentifier = false,
 			pid = 0x3f0a,
-			symbol = "IndexEntryArray")
+			symbol = "IndexEntryArray",
+			// Make this come last in the local set, since it depends on sliceCount and posTableCount values
+			// As per the MXF spec this ordering should not be needed, but if we don't do this
+			// Adobe PremierPro 2022 can't import the files - Adobe pls fix your product!
+			weight = 2147483647)  
 	public IndexEntry[] getIndexEntryArray() 
 		throws PropertyNotPresentException {
 		

--- a/src/main/java/tv/amwa/maj/io/mxf/impl/RandomIndexPackImpl.java
+++ b/src/main/java/tv/amwa/maj/io/mxf/impl/RandomIndexPackImpl.java
@@ -271,13 +271,7 @@ public class RandomIndexPackImpl
 			ByteBuffer ripBytes) 
 		throws BufferUnderflowException {
 
-		UL ripKey = MXFBuilder.readKey(ripBytes);
-		if (ripKey == null)
-			return null;
-		if (!ripKeyValue.equals(ripKey))
-			return null;
-		
-		long ripLength = MXFBuilder.readBERLength(ripBytes);
+		long ripLength = ripBytes.array().length;
 		int ripItemCount = (int) (ripLength - 4) / 12;
 		// If remainder, the random index pack is corrupt in some way.
 		if (((ripLength - 4) % 12) != 0) return null;


### PR DESCRIPTION
Moved DeltaEntry and IndexEntry registryInterfaceMapping calls to before call to Warehouse.registerTypes (as they were not getting run)

This bug manifests when there is a non-empty slice offset property in the index entries (The slice offset bytes are not parsed)